### PR TITLE
Clear previous bytes on stop sampling

### DIFF
--- a/connectionclass/build.gradle
+++ b/connectionclass/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/connectionclass/build.gradle
+++ b/connectionclass/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 22
+        targetSdkVersion 21
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/connectionclass/src/main/java/com/facebook/network/connectionclass/DeviceBandwidthSampler.java
+++ b/connectionclass/src/main/java/com/facebook/network/connectionclass/DeviceBandwidthSampler.java
@@ -97,11 +97,11 @@ public class DeviceBandwidthSampler {
     public void handleMessage(Message msg) {
       switch (msg.what) {
         case MSG_START:
-          addSample(false);
+          addSample();
           sendEmptyMessageDelayed(MSG_START, SAMPLE_TIME);
           break;
         case MSG_STOP:
-          addSample(true);
+          addFinalSample();
           removeMessages(MSG_START);
           break;
         default:
@@ -113,7 +113,7 @@ public class DeviceBandwidthSampler {
      * Method for polling for the change in total bytes since last update and
      * adding it to the BandwidthManager.
      */
-    private void addSample(boolean cleanPreviousReadBytes) {
+    private void addSample() {
       long byteDiff = QTagParser.getInstance().parseDataUsageForUidAndTag(Process.myUid());
       synchronized (this) {
         long curTimeReading = SystemClock.elapsedRealtime();
@@ -121,13 +121,16 @@ public class DeviceBandwidthSampler {
           mConnectionClassManager.addBandwidth(byteDiff, curTimeReading - mLastTimeReading);
         }
         mLastTimeReading = curTimeReading;
-
-        if (cleanPreviousReadBytes) {
-          //Reset previously read bytes so that we don't add bytes downloaded in between
-          // sampling sessions
-          QTagParser.resetPreviousBytes();
-        }
       }
+    }
+
+    /**
+     * Resets previously read byte count after recording a sample, so that
+     * we don't count bytes downloaded in between sampling sessions.
+     */
+    private void addFinalSample() {
+      addSample();
+      QTagParser.resetPreviousBytes();
     }
   }
 

--- a/connectionclass/src/main/java/com/facebook/network/connectionclass/QTagParser.java
+++ b/connectionclass/src/main/java/com/facebook/network/connectionclass/QTagParser.java
@@ -146,4 +146,8 @@ class QTagParser {
     // Return -1 upon error.
     return -1;
   }
+
+  public static void resetPreviousBytes() {
+    sPreviousBytes = -1;
+  }
 }


### PR DESCRIPTION
Issue:
parseDataUsageForUidAndTag() method always calculates diff from last read value of bytes transferred (stored in sPreviousBytes). Consider the following scenario:
1. We call start sampling, initiate network call, end network call,  call end sampling. 'sPreviousBytes' now has the value of rx_bytes from /proc/net/xt_qtaguid/stats file.
2. We make some other network calls in the app which are NOT sampled. rx_bytes in /proc/net/xt_qtaguid/stats gets updated.
3. We call start sampling & initiate another network call.

Now in the first call to addSample method , the diff calculated between the current value of rx_bytes and sPreviousBytes is the amount of data transferred in between the 2 sessions. The time duration for this sample is very small as mLastTimeReading is reset in startSampling method. This results in a incorrect data point being logged.

Fix:
Reset the previous bytes value when a sampling session ends. 
