### PR TITLE
Bug 15 fix - 'Pull request' guideline formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,14 @@ is used directly for issues and pull requests and the developers actively
 respond to requests.
 
 ## Pull Requests
-We actively welcome your pull requests.
+We actively welcome your pull requests. Before submitting a pull request,
+please make sure the following is done:
+
 1. Fork the repo and create your branch from `master`. 
-2. If you've added code that should be tested, add tests
+2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation. 
 4. Ensure the test suite passes. 
-5. Make sure your code lints. 
+5. Make sure your code [lints](https://en.wikipedia.org/wiki/Lint_(software)). 
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributor License Agreement ("CLA")


### PR DESCRIPTION
Fixing the bug#15. 
1. Pull request guidelines points are now formatted in their own line
2. Added a wiki link to indicate what lint roughly means in this context.
   Current guideline about lint is not appropriate for this java project. 
    > 'lint' reference makes more sense for javascript project with grunt.
     Example: https://github.com/facebook/react/blob/master/CONTRIBUTING.md#pull-requests
