### PR TITLE
Use provided scope so we don't include things we don't need in the

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 allprojects {

--- a/connectionclass/build.gradle
+++ b/connectionclass/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    compile 'com.google.code.findbugs:jsr305:2.0.1'
+    provided 'com.google.code.findbugs:jsr305:2.0.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.5-beta'
     testCompile 'org.robolectric:robolectric:3.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip


### PR DESCRIPTION
release artifact.